### PR TITLE
fix stringee listener problems when restart app

### DIFF
--- a/android/src/main/java/com/stringeereactnative/RNStringeeClientModule.java
+++ b/android/src/main/java/com/stringeereactnative/RNStringeeClientModule.java
@@ -42,9 +42,9 @@ public class RNStringeeClientModule extends ReactContextBaseJavaModule implement
         mClient = mStringeeManager.getClient();
         if (mClient == null) {
             mClient = new StringeeClient(getReactApplicationContext());
-            mClient.setConnectionListener(this);
         }
 
+        mClient.setConnectionListener(this);
         mStringeeManager.setClient(mClient);
     }
 

--- a/ios/RNStringeeCall.h
+++ b/ios/RNStringeeCall.h
@@ -18,6 +18,8 @@
 
 @interface RNStringeeCall : RCTEventEmitter <RCTBridgeModule, StringeeCallDelegate>
 
+@property(strong, nonatomic) StringeeCall *stringeeCall;
+
 - (void)addRenderToView:(UIView *)view callId:(NSString *)callId isLocal:(BOOL)isLocal;
 
 @end


### PR DESCRIPTION
Hello Stringee heroes.

When Android app restart  by codepush update or start from background mode. `StringeeClient` already exist  but do not be set new connection listener. Which only settled when initialing new StringeeClient object.

So new incomming call events can not received by` js` listener.

This is `Logivan` fix-version and current be usage in `production level`. 

So hope it can help Stringee product better.

Thanks & best regard